### PR TITLE
ubuntu and debian support

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         distro:
           - rockylinux9
+          - ubuntu2204
+          - debian12
 
     steps:
       - name: Check out the codebase.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 # defaults file for loki
 loki_version: "latest"
-loki_arch: "x86_64"
 loki_http_listen_port: 3100
 loki_http_listen_address: "0.0.0.0"
-loki_expose_port: true
-loki_download_url: "https://github.com/grafana/loki/releases/download/v{{ loki_version }}/loki-{{ loki_version }}.{{ loki_arch }}.rpm"
+loki_expose_port: false
+loki_download_url_rpm: "https://github.com/grafana/loki/releases/download/v{{ loki_version }}/loki-{{ loki_version }}.{{ __loki_arch }}.rpm"
+loki_download_url_deb: "https://github.com/grafana/loki/releases/download/v{{ loki_version }}/loki_{{ loki_version }}_{{ __loki_arch }}.deb"
 loki_working_path: "/var/lib/loki"
 loki_ruler_alert_path: "{{ loki_working_path }}/rules/fake"
 

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -32,13 +32,15 @@
       register: __current_deployed_version
       when: __already_deployed.stat.exists | bool
 
-- name: Install Loki from remote URL
-  ansible.builtin.dnf:
-    name: "{{ loki_download_url }}"
-    state: present
-    disable_gpg_check: true
-  notify: restart loki
-  when: __current_deployed_version.stdout is not defined or loki_version not in __current_deployed_version.stdout
+- name: Include RedHat/Rocky setup
+  ansible.builtin.include_tasks:
+    file: setup-RedHat.yml
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+- name: Include Debian/Ubuntu setup
+  ansible.builtin.include_tasks:
+    file: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
 
 - name: Check if Loki default dir is present
   ansible.builtin.stat:
@@ -63,7 +65,7 @@
     path: "{{ loki_working_path }}"
     state: directory
     owner: "loki"
-    group: "loki"
+    group: "root"
     mode: "0755"
 
 - name: Template Loki config - /etc/loki/config.yml
@@ -81,7 +83,7 @@
     path: "{{ loki_ruler_alert_path }}"
     state: directory
     owner: "loki"
-    group: "loki"
+    group: "root"
     mode: "0750"
   when:
     - loki_ruler_alert_path is defined
@@ -92,7 +94,7 @@
     src: "rules.yml.j2"
     dest: "{{ loki_ruler_alert_path }}/rules.yml"
     owner: "loki"
-    group: "loki"
+    group: "root"
     mode: "0644"
   notify: restart loki
   when:
@@ -111,7 +113,9 @@
     permanent: true
     port: "{{ loki_http_listen_port }}/tcp"
     state: enabled
-  when: __firewalld_service_state.status.ActiveState == "active" and loki_expose_port | bool
+  when:
+    - __firewalld_service_state.status.ActiveState == "active"
+    - loki_expose_port | bool
 
 - name: Ensure that Loki firewalld rule is not present - tcp port {{ loki_http_listen_port }}
   ansible.posix.firewalld:
@@ -119,7 +123,9 @@
     permanent: true
     port: "{{ loki_http_listen_port }}/tcp"
     state: disabled
-  when: __firewalld_service_state.status.ActiveState == "active" and not loki_expose_port | bool
+  when:
+    - __firewalld_service_state.status.ActiveState == "active"
+    - not loki_expose_port | bool
 
 - name: Flush handlers after deployment
   ansible.builtin.meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # tasks file for loki
+- name: Include OS specific variables
+  ansible.builtin.include_vars:
+    file: "{{ ansible_os_family }}.yml"
 
 - name: Deploy Loki service
   ansible.builtin.include_tasks:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,0 +1,7 @@
+---
+- name: APT - Install Loki
+  ansible.builtin.apt:
+    deb: "{{ loki_download_url_deb }}"
+    state: present
+  notify: restart loki
+  when: __current_deployed_version.stdout is not defined or loki_version not in __current_deployed_version.stdout

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,0 +1,8 @@
+---
+- name: DNF - Install Loki from remote URL
+  ansible.builtin.dnf:
+    name: "{{ loki_download_url_rpm }}"
+    state: present
+    disable_gpg_check: true
+  notify: restart loki
+  when: __current_deployed_version.stdout is not defined or loki_version not in __current_deployed_version.stdout

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -12,6 +12,13 @@
     name: "loki"
     state: absent
     autoremove: true
+  when: ansible_os_family in ['RedHat', 'Rocky']
+
+- name: Uninstall Loki deb package
+  ansible.builtin.apt:
+    name: "loki"
+    state: absent
+  when: ansible_os_family == 'Debian'
 
 - name: Ensure that Loki firewalld rule is not present - tcp port {{ loki_http_listen_port }}
   ansible.posix.firewalld:  # noqa ignore-errors

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,5 @@
+---
+__loki_arch_map:
+  x86_64: 'amd64'
+
+__loki_arch: "{{ __loki_arch_map[ansible_architecture] | default(ansible_architecture) }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+__loki_arch: "{{ ansible_architecture }}"


### PR DESCRIPTION
## Features and enhancements

- Added support for Ubuntu and Debian

## Change

- `loki_download_url` replaced with `loki_download_url_rpm` and `loki_download_url_deb`
- `loki_expose_port` default value changed from `true` to `false`

## Deprecations

- Removed `loki_download_url`
- Auto-detection of the architecture. Removed the `loki_arch` variable.
- Molecule testing now includes Ubuntu and Debian.